### PR TITLE
RSDEV-1081: figshare fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Guidelines
+
+## Running Tests
+
+Standard unit and mock-server tests can be run without credentials:
+
+```
+mvn test
+```
+
+When verifying a fix that touches the HTTP layer or the deposit flow, also run the integration tests in `FigshareRSpaceRepositoryAcceptanceTest`. These are `@Ignore`d by default because they require a real Figshare API token:
+
+1. Set the token in `src/test/resources/test.properties`:
+   ```
+   figshareToken=<your-token>
+   ```
+2. Remove the `@Ignore` annotations from `testAccount` and `testUploadZipHTMLArchive`.
+3. Run:
+   ```
+   mvn test -Dtest="FigshareRSpaceRepositoryAcceptanceTest"
+   ```
+4. Restore `@Ignore` and clear the token before committing — do not commit credentials.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.2
+- bump figshare-client-java 0.7.0 -> 0.7.1 (fixes IOException: stream is closed on deposit)
+
 ## 1.1.0
 - bump figshare-client-java 0.6.0 -> 0.7.0 (updates figshare.model.Account to match latest API)
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>figshare-client-java</artifactId>
-      <version>c77a52a8a9</version>
+      <version>582a7a3fad</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-repository-spi</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.2</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>figshare-client-java</artifactId>
-      <version>582a7a3fad</version>
+      <version>0.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>figshare-client-java</artifactId>
-      <version>0.7.0</version>
+      <version>0.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>figshare-client-java</artifactId>
-      <version>7e6ef68682</version>
+      <version>c77a52a8a9</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-figshare-adapter</artifactId>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>Connector between RSpace and Figshare, based on rspace-figshare-client-java lib</description>
 
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>figshare-client-java</artifactId>
-      <version>0.7.1</version>
+      <version>7e6ef68682</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>

--- a/src/test/java/com/researchspace/figshare/rspaceadapter/FigshareRSpaceRepositoryMockServerTest.java
+++ b/src/test/java/com/researchspace/figshare/rspaceadapter/FigshareRSpaceRepositoryMockServerTest.java
@@ -1,0 +1,221 @@
+package com.researchspace.figshare.rspaceadapter;
+
+import com.researchspace.figshare.impl.FileOperationsImpl;
+import com.researchspace.figshare.impl.FigshareTemplate;
+import com.researchspace.figshare.impl.LoggingResponseErrorHandler;
+import com.researchspace.figshare.model.FigshareCategory;
+import com.researchspace.figshare.model.FigshareLicense;
+import com.researchspace.repository.spi.IDepositor;
+import com.researchspace.repository.spi.RepositoryOperationResult;
+import com.researchspace.repository.spi.SubmissionMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+/**
+ * Integration tests for FigshareRSpaceRepository using MockRestServiceServer.
+ *
+ * These tests reproduce the RSDEV-1081 bug: the adapter's submitDeposit flow
+ * calls figshare-client-java POST endpoints that were missing Content-Type:
+ * application/json, causing the Figshare API to reject requests and close the
+ * connection with "java.io.IOException: stream is closed".
+ */
+public class FigshareRSpaceRepositoryMockServerTest {
+
+    private static final String BASE_URL = "https://api.figshare.com/v2";
+    private static final long ARTICLE_ID = 12345L;
+    private static final long FILE_ID = 67890L;
+    private static final String UPLOAD_TOKEN = "test-upload-token";
+    private static final String UPLOAD_URL = "https://fup.figshare.com/upload/" + UPLOAD_TOKEN;
+
+    private FigshareRSpaceRepository repo;
+    private MockRestServiceServer mockServer;
+    private File tempFile;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        RestTemplate restTemplate = new RestTemplate(
+                new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
+        restTemplate.setErrorHandler(new LoggingResponseErrorHandler());
+
+        FigshareTemplate figshareTemplate = new FigshareTemplate("test-token");
+        figshareTemplate.setRestTemplate(restTemplate);
+        figshareTemplate.setFileOps(new FileOperationsImpl(restTemplate, "test-token"));
+
+        repo = new FigshareRSpaceRepository();
+        repo.setFigshare(figshareTemplate);
+
+        // Pre-populate categories and licenses to avoid additional GET requests
+        repo.setCategories(new java.util.ArrayList<>(List.of(new FigshareCategory(25219L, 300L, "Algebra"))));
+        try {
+            repo.setFigshareLicenses(new java.util.ArrayList<>(List.of(
+                    new FigshareLicense(new URL("https://creativecommons.org/licenses/by/4.0/"), "CC BY", 1, true))));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+
+        // small non-zip test file
+        tempFile = File.createTempFile("figshare-adapter-test", ".dat");
+        tempFile.deleteOnExit();
+        Files.write(tempFile.toPath(), new byte[]{1, 2, 3, 4, 5});
+    }
+
+    /**
+     * Reproduces RSDEV-1081: the POST to /account/articles must include
+     * Content-Type: application/json. Before the fix in figshare-client-java 0.7.1
+     * this header was absent and Figshare rejected the request, closing the
+     * connection and causing IOException: stream is closed on the client.
+     */
+    @Test
+    @DisplayName("submitDeposit sends Content-Type: application/json on article and file creation POSTs")
+    void testSubmitDeposit_sendsCorrectContentTypeOnPostRequests() {
+        expectCreateArticle();
+        expectCreatePrivateLink();
+        expectCreateFile();
+        expectGetFileUploadInfo();
+        expectGetUploadProcess();
+        expectUploadPart();
+        expectMarkFileUploadComplete();
+
+        RepositoryOperationResult result = repo.submitDeposit(
+                mockDepositor(), tempFile, testMetadata(), null);
+
+        assertThat(result.isSucceeded()).isTrue();
+        mockServer.verify();
+    }
+
+    /**
+     * Verifies that a 500 response from the article creation endpoint does NOT cause
+     * IOException: stream is closed (the RSDEV-1081 regression).
+     *
+     * Before figshare-client-java 0.7.1, the error handler consumed and closed the
+     * response stream, then RestTemplate tried to read the closed stream, producing
+     * RestClientException wrapping IOException: stream is closed.
+     *
+     * After the fix, the error handler no longer closes the stream prematurely.
+     * createArticle() returns null (error is logged; error handler does not throw for 500),
+     * which causes a NullPointerException downstream — but crucially, NOT stream is closed.
+     */
+    @Test
+    @DisplayName("500 response on article creation does not cause IOException: stream is closed (RSDEV-1081)")
+    void testSubmitDeposit_500ResponseDoesNotCauseStreamClosedException() {
+        mockServer.expect(requestTo(BASE_URL + "/account/articles"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"message\": \"Internal Server Error\", \"code\": 500}"));
+
+        Exception thrown = org.junit.jupiter.api.Assertions.assertThrows(Exception.class,
+                () -> repo.submitDeposit(mockDepositor(), tempFile, testMetadata(), null));
+
+        // Walk the exception chain: none of the messages should contain "stream is closed"
+        Throwable t = thrown;
+        while (t != null) {
+            assertThat(t.getMessage()).doesNotContain("stream is closed");
+            t = t.getCause();
+        }
+        mockServer.verify();
+    }
+
+    // --- mock server expectation helpers ---
+
+    private void expectCreateArticle() {
+        mockServer.expect(requestTo(BASE_URL + "/account/articles"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andRespond(withStatus(HttpStatus.CREATED)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"location\": \"" + BASE_URL + "/account/articles/" + ARTICLE_ID + "\"}"));
+    }
+
+    private void expectCreatePrivateLink() {
+        mockServer.expect(requestTo(BASE_URL + "/account/articles/" + ARTICLE_ID + "/private_links"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withStatus(HttpStatus.CREATED)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"location\": \"https://figshare.com/s/abc123\"}"));
+    }
+
+    private void expectCreateFile() {
+        mockServer.expect(requestTo(BASE_URL + "/account/articles/" + ARTICLE_ID + "/files"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andRespond(withStatus(HttpStatus.CREATED)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"location\": \"" + BASE_URL + "/account/articles/" + ARTICLE_ID + "/files/" + FILE_ID + "\"}"));
+    }
+
+    private void expectGetFileUploadInfo() {
+        mockServer.expect(requestTo(BASE_URL + "/account/articles/" + ARTICLE_ID + "/files/" + FILE_ID))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"id\": " + FILE_ID + ", \"upload_url\": \"" + UPLOAD_URL + "\","
+                                + "\"upload_token\": \"" + UPLOAD_TOKEN + "\","
+                                + "\"status\": \"pending\", \"name\": \"test.dat\", \"size\": 5}"));
+    }
+
+    private void expectGetUploadProcess() {
+        mockServer.expect(requestTo(UPLOAD_URL))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"token\": \"" + UPLOAD_TOKEN + "\","
+                                + "\"parts\": [{\"partNo\": 1, \"startOffset\": 0, \"endOffset\": 4,"
+                                + "\"status\": \"PENDING\", \"locked\": false}],"
+                                + "\"status\": \"PENDING\"}"));
+    }
+
+    private void expectUploadPart() {
+        mockServer.expect(requestTo(UPLOAD_URL + "/1"))
+                .andExpect(method(HttpMethod.PUT))
+                .andRespond(withStatus(HttpStatus.OK).body(""));
+    }
+
+    private void expectMarkFileUploadComplete() {
+        mockServer.expect(requestTo(BASE_URL + "/account/articles/" + ARTICLE_ID + "/files/" + FILE_ID))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withStatus(HttpStatus.ACCEPTED).body(""));
+    }
+
+    private IDepositor mockDepositor() {
+        return new Depositor("test@example.com", "testuser", Collections.emptyList());
+    }
+
+    private SubmissionMetadata testMetadata() {
+        SubmissionMetadata meta = new SubmissionMetadata();
+        IDepositor depositor = mockDepositor();
+        meta.setAuthors(List.of(depositor));
+        meta.setContacts(List.of(depositor));
+        meta.setTitle("Test deposit");
+        meta.setDescription("Test description");
+        meta.setSubjects(List.of("Algebra"));
+        meta.setPublish(false);
+        meta.setLicense(Optional.empty());
+        return meta;
+    }
+}


### PR DESCRIPTION
> This fix was produced by a GitHub Copilot AI agent investigation of RSDEV-1081.

Picks up the fix from figshare-client-java 0.7.1 for RSDEV-1081 (`IOException: stream is closed` on Figshare deposit).

## Changes

- `pom.xml`: bump `figshare-client-java` `0.7.0` → `0.7.1`
- `FigshareRSpaceRepositoryMockServerTest`: 2 new `MockRestServiceServer` tests:
  - Verifies `Content-Type: application/json` is sent on `createArticle` and `createFile` POST requests (the regression that caused the production outage)
  - Verifies a 500 response does not produce `IOException: stream is closed`
- Version bumped `1.1.1` → `1.1.2`